### PR TITLE
Fix SSLInsecureSkipVerify and unused RedirectURL

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -8,3 +8,6 @@ golang.org/x/oauth2                      7fdf09982454086d5570c7db3e11f360194830c
 golang.org/x/net/context                 242b6b35177ec3909636b6cf6a47e8c2c6324b5d
 google.golang.org/api/admin/directory/v1 650535c7d6201e8304c92f38c922a9a3a36c6877
 cloud.google.com/go/compute/metadata     v0.7.0
+github.com/coreos/go-oidc                c797a55f1c1001ec3169f1d0fbb4c5523563bec6
+gopkg.in/square/go-jose.v2               v2.1.1
+github.com/pquerna/cachecontrol          9299cc36e57c32f83e47ffb3c25d8a3dec10ea0b

--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ For adding an application to the Microsoft Azure AD follow [these steps to add a
 
 Take note of your `TenantId` if applicable for your situation. The `TenantId` can be used to override the default `common` authorization server with a tenant specific server.
 
+### OpenID Connect Provider
+
+OpenID Connect is a spec for OAUTH 2.0 + identity that is implemented by many major providers and several open source projects. This provider was originally built against CoreOS Dex and we will use it as an example.
+
+1. Launch a Dex instance using the [getting started guide](https://github.com/coreos/dex/blob/master/Documentation/getting-started.md).
+2. Setup oauth2_proxy with the correct provider and using the default ports and callbacks.
+3. Login with the fixture use in the dex guide.
+
+    -provider oidc
+    -client-id oauth2_proxy
+    -client-secret proxy
+    -redirect-url http://127.0.0.1:4180/oauth2/callback
+    -oidc-issuer-url http://127.0.0.1:5556
+    -cookie-secure=false
+    -email-domain example.com
+
 ## Email Authentication
 
 To authorize by email domain use `--email-domain=yourcompany.com`. To authorize individual email addresses use `--authenticated-emails-file=/path/to/file` with one email per line. To authorize all email addresses use `--email-domain=*`.

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	flagSet.Bool("request-logging", true, "Log requests to stdout")
 
 	flagSet.String("provider", "google", "OAuth provider")
+	flagSet.String("oidc-issuer-url", "", "OpenID Connect issuer URL (ie: https://accounts.google.com)")
 	flagSet.String("login-url", "", "Authentication endpoint")
 	flagSet.String("redeem-url", "", "Token redemption endpoint")
 	flagSet.String("profile-url", "", "Profile access endpoint")

--- a/options.go
+++ b/options.go
@@ -141,6 +141,13 @@ func (o *Options) Validate() error {
 		msgs = append(msgs, "missing setting for email validation: email-domain or authenticated-emails-file required.\n      use email-domain=* to authorize all email addresses")
 	}
 
+	if o.SSLInsecureSkipVerify {
+		insecureTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		http.DefaultClient = &http.Client{Transport: insecureTransport}
+	}
+
 	if o.OIDCIssuerURL != "" {
 		// Configure discoverable provider data.
 		provider, err := oidc.NewProvider(context.Background(), o.OIDCIssuerURL)
@@ -229,13 +236,6 @@ func (o *Options) Validate() error {
 
 	msgs = parseSignatureKey(o, msgs)
 	msgs = validateCookieName(o, msgs)
-
-	if o.SSLInsecureSkipVerify {
-		insecureTransport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		http.DefaultClient = &http.Client{Transport: insecureTransport}
-	}
 
 	if len(msgs) != 0 {
 		return fmt.Errorf("Invalid configuration:\n  %s",

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -1,0 +1,83 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	oidc "github.com/coreos/go-oidc"
+)
+
+type OIDCProvider struct {
+	*ProviderData
+
+	Verifier *oidc.IDTokenVerifier
+}
+
+func NewOIDCProvider(p *ProviderData) *OIDCProvider {
+	return &OIDCProvider{ProviderData: p}
+}
+
+func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err error) {
+	ctx := context.Background()
+	c := oauth2.Config{
+		ClientID:     p.ClientID,
+		ClientSecret: p.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: p.RedeemURL.String(),
+		},
+	}
+	token, err := c.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange: %v", err)
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("token response did not contain an id_token")
+	}
+
+	// Parse and verify ID Token payload.
+	idToken, err := p.Verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return nil, fmt.Errorf("could not verify id_token: %v", err)
+	}
+
+	// Extract custom claims.
+	var claims struct {
+		Email    string `json:"email"`
+		Verified *bool  `json:"email_verified"`
+	}
+	if err := idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("failed to parse id_token claims: %v", err)
+	}
+
+	if claims.Email == "" {
+		return nil, fmt.Errorf("id_token did not contain an email")
+	}
+	if claims.Verified != nil && !*claims.Verified {
+		return nil, fmt.Errorf("email in id_token (%s) isn't verified", claims.Email)
+	}
+
+	s = &SessionState{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		ExpiresOn:    token.Expiry,
+		Email:        claims.Email,
+	}
+
+	return
+}
+
+func (p *OIDCProvider) RefreshSessionIfNeeded(s *SessionState) (bool, error) {
+	if s == nil || s.ExpiresOn.After(time.Now()) || s.RefreshToken == "" {
+		return false, nil
+	}
+
+	origExpiration := s.ExpiresOn
+	s.ExpiresOn = time.Now().Add(time.Second).Truncate(time.Second)
+	fmt.Printf("refreshed access token %s (expired on %s)\n", s, origExpiration)
+	return false, nil
+}

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -28,6 +28,7 @@ func (p *OIDCProvider) Redeem(redirectURL, code string) (s *SessionState, err er
 		Endpoint: oauth2.Endpoint{
 			TokenURL: p.RedeemURL.String(),
 		},
+		RedirectURL: redirectURL,
 	}
 	token, err := c.Exchange(ctx, code)
 	if err != nil {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -30,6 +30,8 @@ func New(provider string, p *ProviderData) Provider {
 		return NewAzureProvider(p)
 	case "gitlab":
 		return NewGitLabProvider(p)
+	case "oidc":
+		return NewOIDCProvider(p)
 	default:
 		return NewGoogleProvider(p)
 	}


### PR DESCRIPTION
Hi Eric,

The PR addresses two issues that I encountered.

1) Using `ssl-insecure-skip-verify` didn't work with the OIDC provider because an HTTP request took place before insecure transport was configured, causing the request to fail due to the certificate authority not being trusted.
2) Redirect URL was not used at all.
